### PR TITLE
Updated A04 to check for and fail if no Projection found, A05 to use …

### DIFF
--- a/ngce/Utility.py
+++ b/ngce/Utility.py
@@ -10,7 +10,6 @@ import string
 import uuid
 import platform
 import sys
-import platform
 
 from pmdm import RunUtil
 from ngce.folders.FoldersConfig import chars, repls
@@ -419,6 +418,34 @@ def getVertCSInfo(spatialReference):
     if vert_unit_name is not None:
         vert_unit_name = str(vert_unit_name).strip().replace("'", "")         
     return vert_cs_name, vert_unit_name
+
+
+def getString(str_value):
+    result = None
+    if str_value is not None:
+        result  = str(str_value).strip().upper()
+        if len(result)<=0:
+            result = None
+    
+    return result
+    
+def getSRValues(spatial_ref):
+    horz_cs_name = None
+    horz_cs_unit_name = None
+    horz_cs_factory_code = None
+    vert_cs_name, vert_unit_name = None, None
+    
+    if spatial_ref is not None:
+        horz_cs_name = getString(spatial_ref.name)
+        horz_cs_unit_name = getString(spatial_ref.linearUnitName)
+        horz_cs_factory_code = getString(spatial_ref.factoryCode)
+        vert_cs_name, vert_unit_name = getVertCSInfo(spatial_ref)
+        
+        vert_cs_name = getString(vert_cs_name)
+        vert_unit_name = getString(vert_unit_name)
+    
+    return horz_cs_name, horz_cs_unit_name, horz_cs_factory_code, vert_cs_name, vert_unit_name
+
     
 def clearFolder(folder):
     if os.path.exists(folder):

--- a/ngce/las/LAS.py
+++ b/ngce/las/LAS.py
@@ -257,8 +257,13 @@ class QALasInfo(object):
     
     def isValidSpatialReference(self):
         sr = self.getSpatialReference()
+        
         result = False
         if sr is not None:
+            try:
+                sr.factoryCode
+            except:
+                sr = arcpy.SpatialReference(sr)
             result = (sr.factoryCode is not None and sr.factoryCode > 0)
             if sr.factoryCode is None:
                 arcpy.AddMessage("Spatial reference exists, but WKID (EPSG Code) is None. The custom projection for this project may not be able to be converted when published to the master.")
@@ -273,8 +278,14 @@ class QALasInfo(object):
 
     def isUnknownSpatialReference(self):
         sr = self.getSpatialReference()
+        
+            
         result = False
         if sr is not None:
+            try:
+                sr.name
+            except:
+                sr = arcpy.SpatialReference(sr)
             result = sr.name is None or sr.name.lower() == 'unknown'
             if result:
                 arcpy.AddMessage("Spatial reference is UNKNOWN, please add a .prj file to the las directory or spatial reference information to the las files.")

--- a/ngce/pmdm/a/A05_A_RemoveDEMErrantValues.py
+++ b/ngce/pmdm/a/A05_A_RemoveDEMErrantValues.py
@@ -83,9 +83,9 @@ from ngce.pmdm.a.A05_B_RevalueRaster import FIELD_INFO, MIN, MAX, V_NAME, V_UNIT
     H_NAME, H_UNIT, H_WKID, doTime
 
 
-PROCESS_DELAY = 2
-PROCESS_CHUNKS = 4  # files per thread. Factor of 2 please
-PROCESS_SPARES = 0  # processors to leave as spares, no more than 4!
+PROCESS_DELAY = 10
+PROCESS_CHUNKS = 6  # files per thread. Factor of 2 please
+PROCESS_SPARES = 1  # processors to leave as spares, no more than 4!
 
 def getBoundData(bound_path):
     


### PR DESCRIPTION
….tif for raster formats without an extension (bug in arcpy multiprocessing that shares a scratch workspace and causes random failures).